### PR TITLE
Integrate GitHub repository fetching functionality

### DIFF
--- a/src/@types/Repository.d.ts
+++ b/src/@types/Repository.d.ts
@@ -1,0 +1,11 @@
+export interface Repository {
+  full_name:string;
+  stargazers_count: number
+  watchers_count: number;
+  html_url: string;
+  description: string;
+  private: boolean
+  language: string;
+
+
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import GithubLogo from './assets/github.svg';
 import { FormContainer } from './components/FormContainer';
 import { FormProps } from './@types/FormContainer';
-import { ChangeEvent, FormEvent, MouseEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, MouseEvent, useEffect, useState } from 'react';
+import { useGithub } from './hooks/useGithub.ts';
 import { z } from 'zod';
+
 const inputNameSchema = z.string().regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9-._$]/);
 
 export default function App() {
@@ -10,17 +12,17 @@ export default function App() {
   const [isValid, setIsValid] = useState<boolean>(false);
   const { repository, loading, error, fetchRepository } = useGithub();
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     try {
-      console.log("Form Submitted");
-
+      await fetchRepository(inputValue);
     } catch (e) {
-      console.log(e);
+      console.log(`this error is in the catch: ${e}`);
     } finally {
       setInputValue("");
     }
   };
+
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);

--- a/src/components/FormContainer/index.tsx
+++ b/src/components/FormContainer/index.tsx
@@ -16,6 +16,6 @@ export function FormContainer({ formProps }: FormContainerProps) {
       value={formProps.inputValue}
       onChange={formProps.inputOnChange}
     />
-    <Button type={'button'} disabled={!formProps.inputValid} label={"Buscar"} onClick={formProps.buttonOnClick}/>
+    <Button type={'submit'} disabled={!formProps.inputValid} label={"Buscar"} onClick={formProps.buttonOnClick}/>
   </StyledFormContainer>;
 }

--- a/src/hooks/useGithub.ts
+++ b/src/hooks/useGithub.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { Repository } from '../@types/Repository';
+import { getRepoDetails } from '../services/githubService.ts';
+
+export function useGithub() {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | unknown | null>(null);
+  const [repository, setRepository] = useState<Repository | null>(null);
+
+  const fetchRepository = async (fullName: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await getRepoDetails(fullName);
+      setRepository(res);
+    } catch (e) {
+      setError(e);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+      console.log(repository);
+    },
+    [repository]);
+
+  return {
+    repository,
+    loading,
+    error,
+    fetchRepository
+  };
+}

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -1,0 +1,20 @@
+const API_BASE_URL = 'https://api.github.com/repos';
+
+export async function getRepoDetails(repoFullName: string) {
+  const response = await fetch(`${API_BASE_URL}/${repoFullName}`);
+
+  if (!response.ok) {
+    throw new Error(`${response.status}`);
+  }
+
+  const responseJson = await response.json()
+  return {
+    description: responseJson.description,
+    html_url: responseJson.html_url,
+    full_name: responseJson.full_name,
+    stargazers_count: responseJson.stargazers_count,
+    watchers_count: responseJson.watchers_count,
+    private: responseJson.private,
+    language: responseJson.language
+  }
+}


### PR DESCRIPTION
# Summary
This Pull Request introduces functionality to fetch and display details of a GitHub repository by integrating a new custom hook and service for API communication. It also includes related interface definition updates and minor UI adjustments.
## Main Changes:
- Addition of Repository interface (Repository.d.ts): Defines the structure for repository data.
- Update in App.tsx: Integrated the useGithub hook, updated the input handling, and enabled asynchronous form submission to fetch repository data.
- Modification in FormContainer/index.tsx: Adjusted the button type from "button" to "submit" for proper form submission.
- New custom hook (useGithub.ts): Handles API call logic, repository state management, and error handling.
- New service (githubService.ts): Implements a function that communicates with the GitHub API to fetch repository details.